### PR TITLE
Avoid walking into node_modules manually

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,7 +197,7 @@ Cssdoc.prototype.combineCss = function() {
   var styleCss = this.cssContents.join('');
   var templCss = fs.readFileSync( templatePath + '/style.css', 'utf8');
   var highlight = '';
-  highlight = fs.readFileSync( __dirname + '/node_modules/highlight.js/styles/' + this.opts.highlightTheme + '.css', 'utf8');
+  highlight = fs.readFileSync( require.resolve('highlight.js/styles/' + this.opts.highlightTheme + '.css'), 'utf8');
 
   fs.copySync( templatePath + '/logo.png', this.opts.destination + '/img/logo.png');
 


### PR DESCRIPTION
This improves the resolution logic of the `highlight.js` dependency path, so it works when you use npm@3 to install Cssdoc as a dependency of another project.
